### PR TITLE
Remove scheduled run

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -5,8 +5,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  schedule:
-    - cron:  '* * * * *'
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
This is pushing an image to Docker Hub every minute, rather than
just when the image needs to be updated. This is causing unnecessary
traffic.

Justin

Signed-off-by: Justin Cormack <justin@specialbusservice.com>